### PR TITLE
Fixed improper unfair lock initialization that crashes smcutil on macOS Monterey

### DIFF
--- a/BatteryStatusShow/smc.c
+++ b/BatteryStatusShow/smc.c
@@ -74,7 +74,7 @@ kern_return_t SMCOpen(const char *serviceName, io_connect_t *conn)
     io_iterator_t iterator;
     io_object_t   device;
 
-    IOMasterPort(MACH_PORT_NULL, &masterPort);
+    IOMainPort(MACH_PORT_NULL, &masterPort);
 
     CFMutableDictionaryRef matchingDictionary = IOServiceMatching(serviceName);
     result = IOServiceGetMatchingServices(masterPort, matchingDictionary, &iterator);


### PR DESCRIPTION
smcutil will crash on macOS Monterey (12.0.1) due to an uninitialized unfair lock on the stack. This patch fixes it by properly initializing the lock.